### PR TITLE
Implement check

### DIFF
--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"os"
+
+	"github.com/tylerrasor/defectdojo-resource/internal/check"
+	"github.com/tylerrasor/defectdojo-resource/internal/concourse"
+)
+
+func main() {
+	w := concourse.AttachToWorker(
+		os.Stdin,
+		os.Stderr,
+		os.Stdout,
+		os.Args,
+	)
+
+	if err := check.Check(w); err != nil {
+		w.LogError("%s", err)
+		os.Exit(1)
+	}
+}

--- a/internal/check/check_request.go
+++ b/internal/check/check_request.go
@@ -1,0 +1,23 @@
+package check
+
+import (
+	"encoding/json"
+
+	"github.com/tylerrasor/defectdojo-resource/internal/concourse"
+)
+
+type CheckRequest struct {
+	Source  concourse.Source  `json:"source"`
+	Version concourse.Version `json:"version"`
+}
+
+func DecodeToCheckRequest(w *concourse.Worker) (*CheckRequest, error) {
+	decoder := json.NewDecoder(w.Stdin)
+	decoder.DisallowUnknownFields()
+
+	var req CheckRequest
+	if err := decoder.Decode(&req); err != nil {
+		return nil, err
+	}
+	return &req, nil
+}

--- a/internal/check/check_request_test.go
+++ b/internal/check/check_request_test.go
@@ -1,0 +1,83 @@
+package check_test
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tylerrasor/defectdojo-resource/internal/check"
+	"github.com/tylerrasor/defectdojo-resource/internal/concourse"
+)
+
+func TestDecodeToCheckRequestThrowsErrorWhenUnexpectedKey(t *testing.T) {
+	var mock_stdin bytes.Buffer
+
+	mock_stdin.Write([]byte(`
+	{
+		"source": {},
+		"version": {},
+		"unexpectedkey": {}
+	}`))
+
+	w := concourse.AttachToWorker(
+		&mock_stdin,
+		os.Stderr,
+		os.Stdout,
+		nil,
+	)
+
+	check, err := check.DecodeToCheckRequest(w)
+
+	assert.NotNil(t, err)
+	assert.Nil(t, check)
+}
+
+func TestDecodeToCheckRequestWorks(t *testing.T) {
+	var mock_stdin bytes.Buffer
+
+	mock_stdin.Write([]byte(`
+	{
+		"source": {
+			"defectdojo_url": "something"
+		},
+		"version": {
+			"engagement_id": "5"
+		}
+	}`))
+
+	w := concourse.AttachToWorker(
+		&mock_stdin,
+		os.Stderr,
+		os.Stdout,
+		nil,
+	)
+
+	check, err := check.DecodeToCheckRequest(w)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, check)
+}
+
+func TestDecodeToCheckRequestWorksWhenNoVersionGiven(t *testing.T) {
+	var mock_stdin bytes.Buffer
+
+	mock_stdin.Write([]byte(`
+	{
+		"source": {
+			"defectdojo_url": "something"
+		}
+	}`))
+
+	w := concourse.AttachToWorker(
+		&mock_stdin,
+		os.Stderr,
+		os.Stdout,
+		nil,
+	)
+
+	check, err := check.DecodeToCheckRequest(w)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, check)
+}

--- a/internal/check/command.go
+++ b/internal/check/command.go
@@ -1,4 +1,4 @@
-package in
+package check
 
 import (
 	"fmt"
@@ -7,8 +7,8 @@ import (
 	"github.com/tylerrasor/defectdojo-resource/pkg/defectdojo_client"
 )
 
-func Get(w *concourse.Worker) error {
-	request, err := DecodeToGetRequest(w)
+func Check(w *concourse.Worker) error {
+	request, err := DecodeToCheckRequest(w)
 	if err != nil {
 		return fmt.Errorf("invalid payload: %s", err)
 	}
@@ -18,16 +18,16 @@ func Get(w *concourse.Worker) error {
 	}
 
 	client := defectdojo_client.NewDefectdojoClient(request.Source.DefectDojoUrl, request.Source.ApiKey)
-	something, err := client.GetSomethingForIn()
+
+	e, err := client.GetEngagement(request.Version.EngagementId)
 	if err != nil {
-		return fmt.Errorf("error getting something: %s", err)
+		return fmt.Errorf("error getting engagement: %s", err)
 	}
-	w.LogDebug(something)
 
 	w.LogDebug("building response object")
 	r := concourse.Response{
 		Version: concourse.Version{
-			EngagementId: "need to figure out unique combination of app name, version, build number, something",
+			EngagementId: fmt.Sprint(e.EngagementId),
 		},
 	}
 	if err := w.OutputResponseToConcourse(r); err != nil {

--- a/internal/check/command_test.go
+++ b/internal/check/command_test.go
@@ -1,0 +1,1 @@
+package check_test

--- a/internal/check/command_test.go
+++ b/internal/check/command_test.go
@@ -1,1 +1,76 @@
 package check_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tylerrasor/defectdojo-resource/internal/check"
+	"github.com/tylerrasor/defectdojo-resource/internal/concourse"
+)
+
+func TestCheckErrorsWhenUnexpectedKeysInConcourseRequest(t *testing.T) {
+	req := `{ "key": "unexpected" }`
+	mock_stdin := bytes.NewBuffer([]byte(req))
+	w := concourse.AttachToWorker(
+		mock_stdin,
+		nil,
+		nil,
+		nil,
+	)
+
+	err := check.Check(w)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid payload: ")
+}
+
+func TestCheckErrorsWhenGetEngagementFails(t *testing.T) {
+	req := `{ "source": {}, "version": {} }`
+	mock_stdin := bytes.NewBuffer([]byte(req))
+	w := concourse.AttachToWorker(
+		mock_stdin,
+		nil,
+		nil,
+		nil,
+	)
+
+	err := check.Check(w)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "error getting engagement: ")
+}
+
+func TestCheckPutsEngagementIdAsVersion(t *testing.T) {
+	id := 15
+	mock_server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		e := fmt.Sprintf(`{ "id":%d,"target_start":"2021-02-04","target_end":"2021-02-04","product":5,"name":"name"}`, id)
+		io.WriteString(w, e)
+	}))
+
+	req := fmt.Sprintf(`{ "source": { "defectdojo_url": "%s", "debug": true }, "version": {} }`, mock_server.URL)
+	mock_stdin := bytes.NewBuffer([]byte(req))
+	var mock_stdout bytes.Buffer
+	w := concourse.AttachToWorker(
+		mock_stdin,
+		nil,
+		&mock_stdout,
+		nil,
+	)
+
+	err := check.Check(w)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, mock_stdout)
+
+	var r concourse.Response
+	decoder := json.NewDecoder(&mock_stdout)
+	decoder.Decode(&r)
+	assert.Equal(t, fmt.Sprint(id), r.Version.EngagementId)
+}

--- a/internal/check/command_test.go
+++ b/internal/check/command_test.go
@@ -54,7 +54,7 @@ func TestCheckPutsEngagementIdAsVersion(t *testing.T) {
 		io.WriteString(w, e)
 	}))
 
-	req := fmt.Sprintf(`{ "source": { "defectdojo_url": "%s", "debug": true }, "version": {} }`, mock_server.URL)
+	req := fmt.Sprintf(`{ "source": { "defectdojo_url": "%s" }, "version": {} }`, mock_server.URL)
 	mock_stdin := bytes.NewBuffer([]byte(req))
 	var mock_stdout bytes.Buffer
 	w := concourse.AttachToWorker(

--- a/internal/concourse/models.go
+++ b/internal/concourse/models.go
@@ -10,7 +10,7 @@ type Response struct {
 }
 
 type Version struct {
-	Version string `json:"version"`
+	EngagementId string `json:"engagement_id"`
 }
 
 type Source struct {

--- a/internal/concourse/worker_test.go
+++ b/internal/concourse/worker_test.go
@@ -24,14 +24,14 @@ func TestOutputVersionResponseToConcourse(t *testing.T) {
 
 	r := concourse.Response{
 		Version: concourse.Version{
-			Version: "0.1",
+			EngagementId: "0.1",
 		},
 	}
 
 	err := w.OutputResponseToConcourse(r)
 
 	assert.Nil(t, err)
-	expected := fmt.Sprintf("{\"version\":{\"version\":\"%s\"}}\n", r.Version.Version)
+	expected := fmt.Sprintf("{\"version\":{\"engagement_id\":\"%s\"}}\n", r.Version.EngagementId)
 	assert.Equal(t, expected, mock_stdout.String())
 }
 

--- a/internal/out/command.go
+++ b/internal/out/command.go
@@ -58,7 +58,7 @@ func Put(w *concourse.Worker) error {
 
 	r := concourse.Response{
 		Version: concourse.Version{
-			Version: fmt.Sprint(e.EngagementId),
+			EngagementId: fmt.Sprint(e.EngagementId),
 		},
 	}
 	if err := w.OutputResponseToConcourse(r); err != nil {

--- a/pkg/defectdojo_client/engagements.go
+++ b/pkg/defectdojo_client/engagements.go
@@ -20,6 +20,22 @@ type Engagement struct {
 	EngagementName   string `json:"name"`
 }
 
+func (c *DefectdojoClient) GetEngagement(id string) (*Engagement, error) {
+	path := fmt.Sprintf("engagements/%s", id)
+	params := map[string]string{}
+	resp, err := c.DoGet(path, params)
+	if err != nil {
+		return nil, err
+	}
+
+	var e *Engagement
+	decoder := json.NewDecoder(resp.Body)
+	if err := decoder.Decode(&e); err != nil {
+		return nil, fmt.Errorf("error decoding response: %s", err)
+	}
+	return e, nil
+}
+
 func (c *DefectdojoClient) CreateEngagement(p *Product, report_type string, close_engagement bool) (*Engagement, error) {
 	ts := time.Now().String()
 	name := fmt.Sprintf("%s - %s", report_type, ts)

--- a/pkg/defectdojo_client/engagements_test.go
+++ b/pkg/defectdojo_client/engagements_test.go
@@ -13,6 +13,24 @@ import (
 	"github.com/tylerrasor/defectdojo-resource/pkg/defectdojo_client"
 )
 
+func TestGetEngagement(t *testing.T) {
+	id := 18
+	mock_server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		mock_date := "2021-02-04"
+		e := fmt.Sprintf(`{ "id":%d,"target_start":"%s","target_end":"%s","product":5,"name":"name"}`, id, mock_date, mock_date)
+		io.WriteString(w, e)
+	}))
+
+	c := defectdojo_client.NewDefectdojoClient(mock_server.URL, "api_key")
+
+	e, err := c.GetEngagement(fmt.Sprint(id))
+
+	assert.Nil(t, err)
+	assert.NotNil(t, e)
+	assert.Equal(t, id, e.EngagementId)
+}
+
 func TestCreateEngagementSetsReportName(t *testing.T) {
 	id := 18
 	target_date := "2021-01-01"


### PR DESCRIPTION
just happy path, this will break on first run

from: https://concourse-ci.org/implementing-resource-types.html
```
This will be omitted from the first request, in which case the resource should return the current version (not every version since the resource's inception).
```