### PR TITLE
import-scan file upload returns the field 'engagement' as the engagem…

### DIFF
--- a/internal/out/command.go
+++ b/internal/out/command.go
@@ -58,7 +58,7 @@ func Put(w *concourse.Worker) error {
 
 	r := concourse.Response{
 		Version: concourse.Version{
-			EngagementId: fmt.Sprint(e.EngagementId),
+			EngagementId: fmt.Sprint(e.EngagementIdFromUpload),
 		},
 	}
 	if err := w.OutputResponseToConcourse(r); err != nil {

--- a/internal/out/command_test.go
+++ b/internal/out/command_test.go
@@ -280,8 +280,10 @@ func TestPutWhenEverythingGoesRightOutputsVersionToConcourse(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		if r.RequestURI == fmt.Sprintf("/api/v2/products/?name=%s", product_name) {
 			results = fmt.Sprintf(`{ "results": [ { "id": %d, "name": "%s" } ] }`, id, product_name)
-		} else if (r.RequestURI == "/api/v2/engagements/" && r.Method == "POST") || (r.RequestURI == "/api/v2/import-scan/" && r.Method == "POST") {
+		} else if r.RequestURI == "/api/v2/engagements/" && r.Method == "POST" {
 			results = fmt.Sprintf(`{ "id":%d,"target_start":"2021-03-07","target_end":"2021-03-07","product":5,"name":"name"}`, id)
+		} else if r.RequestURI == "/api/v2/import-scan/" && r.Method == "POST" {
+			results = fmt.Sprintf(`{ "engagement":%d,"target_start":"2021-03-07","target_end":"2021-03-07","product":5,"name":"name"}`, id)
 		} else {
 			assert.Fail(t, "shouldn't call any other endpoints", r.RequestURI)
 		}

--- a/pkg/defectdojo_client/engagements.go
+++ b/pkg/defectdojo_client/engagements.go
@@ -16,13 +16,14 @@ type EngagementSearchResults struct {
 }
 
 type Engagement struct {
-	EngagementId     int    `json:"id,omitempty"`
-	ProductId        int    `json:"product"`
-	StartDate        string `json:"target_start"`
-	EndDate          string `json:"target_end"`
-	EngagementType   string `json:"engagement_type"`
-	EngagementStatus string `json:"status,omitempty"`
-	EngagementName   string `json:"name"`
+	EngagementId           int    `json:"id,omitempty"`
+	EngagementIdFromUpload int    `json:"engagement,omitempty"`
+	ProductId              int    `json:"product"`
+	StartDate              string `json:"target_start"`
+	EndDate                string `json:"target_end"`
+	EngagementType         string `json:"engagement_type"`
+	EngagementStatus       string `json:"status,omitempty"`
+	EngagementName         string `json:"name"`
 }
 
 func (c *DefectdojoClient) GetEngagement(id string) (*Engagement, error) {

--- a/pkg/defectdojo_client/engagements_test.go
+++ b/pkg/defectdojo_client/engagements_test.go
@@ -238,7 +238,7 @@ func TestUploadReport(t *testing.T) {
 	report_type := "report"
 	mock_server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		e := fmt.Sprintf(`{ "id":%d,"target_start":"%s","target_end":"%s","product":%d,"name":"%s"}`, id, target_date, target_date, app_id, report_type)
+		e := fmt.Sprintf(`{ "engagement":%d,"target_start":"%s","target_end":"%s","product":%d,"name":"%s"}`, id, target_date, target_date, app_id, report_type)
 		io.WriteString(w, e)
 	}))
 
@@ -248,7 +248,7 @@ func TestUploadReport(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.NotNil(t, e)
-	assert.Equal(t, e.EngagementId, id)
+	assert.Equal(t, e.EngagementIdFromUpload, id)
 	assert.Equal(t, e.EngagementName, report_type)
 	assert.Equal(t, e.ProductId, app_id)
 	assert.Equal(t, e.StartDate, target_date)

--- a/pkg/defectdojo_client/util_test.go
+++ b/pkg/defectdojo_client/util_test.go
@@ -43,7 +43,7 @@ func TestBuildJsonRequestBytez(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.NotNil(t, bytez)
-	assert.Equal(t, bytez, expected)
+	assert.Equal(t, expected, bytez)
 }
 
 func TestBuildMultipartFormBytez(t *testing.T) {


### PR DESCRIPTION
…ent_id instead of just 'id' like the /engagements endpoints